### PR TITLE
fix: signature of consent object

### DIFF
--- a/src/pure.ts
+++ b/src/pure.ts
@@ -320,12 +320,12 @@ export class Ketch {
     if (this._consent.hasValue()) {
       c = this._consent.getValue();
     } else {
-      c = Promise.resolve({} as Consent);
+      c = Promise.resolve({purposes: {}, vendors: []} as Consent);
     }
 
     return c.then(consent => {
       if (consent === undefined) {
-        return {} as Consent;
+        return {purposes: {}, vendors: []} as Consent;
       }
 
       if (this._showConsentExperience) {
@@ -479,7 +479,7 @@ export class Ketch {
       return this._consent.getValue() as Promise<Consent>;
     }
 
-    return Promise.resolve({} as Consent)
+    return Promise.resolve({purposes: {}, vendors: []} as Consent)
   }
 
   /**
@@ -1109,7 +1109,7 @@ export class Ketch {
   showPreferenceExperience(): Promise<Consent> {
     log.info('showPreference');
 
-    const c: Promise<Consent> = this.hasConsent() ? this.getConsent(): Promise.resolve({purposes: {}});
+    const c: Promise<Consent> = this.hasConsent() ? this.getConsent(): Promise.resolve({purposes: {}, vendors: []});
 
     return c.then(c => {
       // if no preference experience configured do not show
@@ -1218,7 +1218,7 @@ export class Ketch {
       })
     }
 
-    return Promise.resolve({} as Consent)
+    return Promise.resolve({purposes: {}, vendors: []} as Consent)
   }
 
   /**

--- a/test/preferences.test.ts
+++ b/test/preferences.test.ts
@@ -12,13 +12,13 @@ describe('preferences', () => {
         }
       } as any) as Configuration);
 
-      expect(ketch.showPreferenceExperience()).resolves.toBeUndefined();
+      return expect(ketch.showPreferenceExperience()).resolves.toStrictEqual({"purposes": {}, "vendors": []});
     });
 
     it('does not show experience', () => {
       const ketch = new Ketch({} as Configuration);
 
-      expect(ketch.showPreferenceExperience()).resolves.toBeUndefined();
+      return expect(ketch.showPreferenceExperience()).resolves.toStrictEqual({"purposes": {}, "vendors": []});
     });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Fixes the signature of the consent object to always be consistent and always have "purposes" and "vendors".

## Why is this change being made?
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [X] I have informed stakeholders of my changes.
