### PR TITLE
fix(invokeRight): rightCode + swbPermit backward compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4192,9 +4192,9 @@
       }
     },
     "@ketch-sdk/ketch-web-api": {
-      "version": "0.1.37",
-      "resolved": "https://registry.npmjs.org/@ketch-sdk/ketch-web-api/-/ketch-web-api-0.1.37.tgz",
-      "integrity": "sha512-kb9AWptxLrzR73wUh+QhNghX23qrYnkAlDD6UOMvA8cwfkziI04cR1g+5dw9lMC7CAtgA8aJlWJD13CEIIHZRw=="
+      "version": "0.1.38",
+      "resolved": "https://registry.npmjs.org/@ketch-sdk/ketch-web-api/-/ketch-web-api-0.1.38.tgz",
+      "integrity": "sha512-oUUP9JJiZxVeyrS3u0wsaHzRn3taW5ZByUsRV7wIMNFL+AgNmm766B2nHolTctvp8QnRofne2l+usxCxaKkxOw=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@ketch-sdk/ketch-plugin": "^0.2.17",
-    "@ketch-sdk/ketch-web-api": "^0.1.37",
+    "@ketch-sdk/ketch-web-api": "^0.1.38",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/src/pure.ts
+++ b/src/pure.ts
@@ -397,16 +397,21 @@ export class Ketch {
   triggerPermitChangedEvent(c: Consent): void {
     log.info('triggerPermitChangedEvent');
 
-    // c
     const permitChangedEvent: {[key: string]: any} = {
       event: 'ketchPermitChanged',
     }
 
+    const swbPermitChangedEvent: {[key: string]: any} = {
+      event: 'switchbitPermitChanged',
+    }
+
     for (const purposeCode in c.purposes) {
       permitChangedEvent[purposeCode] = c.purposes[purposeCode]
+      swbPermitChangedEvent[purposeCode] = c.purposes[purposeCode]
     }
 
     dataLayer().push(permitChangedEvent)
+    dataLayer().push(swbPermitChangedEvent)
   }
 
   /**
@@ -1214,7 +1219,7 @@ export class Ketch {
       controllerCode: '',
       identities: identities,
       jurisdictionCode: this._config.jurisdiction.code || '',
-      rightCodes: [eventData.right],
+      rightCode: eventData.right,
       user: user
     };
 

--- a/test/consent.test.ts
+++ b/test/consent.test.ts
@@ -303,7 +303,7 @@ describe('consent', () => {
     it('skips if no consents', () => {
       const ketch = new Ketch(config);
 
-      return ketch.updateConsent(identities, {}).then((x) => {
+      return ketch.updateConsent(identities, {purposes:{}}).then((x) => {
         expect(x).toBeUndefined();
       });
     });

--- a/test/rights.test.ts
+++ b/test/rights.test.ts
@@ -86,7 +86,7 @@ describe('gangplank', () => {
             controllerCode: '',
             identities,
             jurisdictionCode: jurisdiction.code,
-            rightCodes: ['portability'],
+            rightCode: 'portability',
             user: {
               first: 'first',
               last: 'last',
@@ -97,44 +97,6 @@ describe('gangplank', () => {
             }
           });
         }
-      });
-    });
-
-    it('skips if no identities', () => {
-      return ketch.invokeRight([], data).then(() => {
-        // expect(fetch).not.toHaveBeenCalled();
-      });
-    });
-
-    const dataNoEmail = {
-      right: 'portability',
-      firstName: '',
-      lastName: '',
-      rightsEmail: '',
-      country: '',
-      state: '',
-      details: ''
-    }
-
-    it('skips if no rightsEmail', () => {
-      return ketch.invokeRight(identities, dataNoEmail).then(() => {
-        // expect(fetch).not.toHaveBeenCalled();
-      });
-    });
-
-    const dataNoRight = {
-      right: '',
-      firstName: '',
-      lastName: '',
-      rightsEmail: 'rights@email.com',
-      country: '',
-      state: '',
-      details: ''
-    }
-
-    it('skips if no rights', () => {
-      return ketch.invokeRight(identities, dataNoRight).then(() => {
-        // expect(fetch).not.toHaveBeenCalled();
       });
     });
   });

--- a/test/rights.test.ts
+++ b/test/rights.test.ts
@@ -99,5 +99,41 @@ describe('gangplank', () => {
         }
       });
     });
+
+    const dataNoEmail = {
+      right: 'portability',
+      firstName: '',
+      lastName: '',
+      rightsEmail: '',
+      country: '',
+      state: '',
+      details: ''
+    }
+
+    it('skips if no rightsEmail', () => {
+      const mockInvokeRight = mocked(invokeRight);
+      mockInvokeRight.mockResolvedValue();
+      return ketch.invokeRight(dataNoEmail).then(() => {
+        expect(mockInvokeRight).not.toHaveBeenCalled();
+      });
+    });
+
+    const dataNoRight = {
+      right: '',
+      firstName: '',
+      lastName: '',
+      rightsEmail: 'rights@email.com',
+      country: '',
+      state: '',
+      details: ''
+    }
+
+    it('skips if no rights', () => {
+      const mockInvokeRight = mocked(invokeRight);
+      mockInvokeRight.mockResolvedValue();
+      return ketch.invokeRight(dataNoRight).then(() => {
+        expect(mockInvokeRight).not.toHaveBeenCalled();
+      });
+    });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Update invokeRights to use a single rightCode per shoreline spec
Include switchbitPermitChanged for backwards compatibility
Update tests

## Why is this change being made?
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
