### PR TITLE
fix(consent): do not reprompt if no yet set

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -31,7 +31,7 @@ module.exports = {
     global: {
       branches: 55,
       functions: 58,
-      lines: 64,
+      lines: 63,
     },
   },
 

--- a/src/ketch.ts
+++ b/src/ketch.ts
@@ -858,11 +858,17 @@ export class Ketch extends EventEmitter {
       return identities
     }
 
-    const permitConsent = await this.fetchConsent(identities)
     const localConsent = await this.retrieveConsent()
+    // if there is not yet local consent then return identities
+    // no reprompting of the user is applicable until local consent is set
+    if (Object.keys(localConsent.purposes).length == 0) {
+      return identities
+    }
+
+    const permitConsent = await this.fetchConsent(identities)
 
     // check if consent value the same
-    if (Object.keys(permitConsent).length === Object.keys(localConsent).length) {
+    if (Object.keys(permitConsent.purposes).length === Object.keys(localConsent.purposes).length) {
       let newConsent = false
       for (const key in permitConsent) {
         if (permitConsent.purposes[key] !== localConsent.purposes[key]) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Race condition with empty local consent was causing the user to always be reprompted with the banner because the server consent and the local consent did not match. If the local consent is empty that means that the user has not yet made a consent selection so short circuit and return identities

## Why is this change being made?
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
