### PR TITLE
fix: strings in native callbacks

### DIFF
--- a/src/ketch.ts
+++ b/src/ketch.ts
@@ -1317,22 +1317,20 @@ export class Ketch extends EventEmitter {
         argument = args[0]
       } else if (args.length === 1) {
         argument = JSON.stringify(args[0])
-      } else {
+      } else if (args.length > 1) {
         argument = JSON.stringify(args)
       }
 
-      if (window.androidListener) {
-        if (eventName in window.androidListener) {
+      if (window.androidListener && eventName in window.androidListener) {
+        if (args.length === 0) {
+          window.androidListener[eventName]()
+        } else {
           window.androidListener[eventName](argument)
-        } else {
-          console.warn(`Can't pass message to native code because "${eventName}" handler is not registered`)
         }
-      } else if (window.webkit?.messageHandlers) {
-        if (eventName in window.webkit.messageHandlers) {
-          window.webkit.messageHandlers[eventName].postMessage(argument)
-        } else {
-          console.warn(`Can't pass message to native code because "${eventName}" handler is not registered`)
-        }
+      } else if (window.webkit?.messageHandlers && eventName in window.webkit.messageHandlers) {
+        window.webkit.messageHandlers[eventName].postMessage(argument)
+      } else {
+        console.warn(`Can't pass message to native code because "${eventName}" handler is not registered`)
       }
     }
     return super.emit(event, ...args)

--- a/src/ketch.ts
+++ b/src/ketch.ts
@@ -1312,18 +1312,18 @@ export class Ketch extends EventEmitter {
     if (window.androidListener || window.webkit?.messageHandlers) {
       const eventName = event.toString()
 
-      let argument;
+      let argument
       if (args.length === 1 && typeof args[0] === 'string') {
-        argument = args[0];
+        argument = args[0]
       } else if (args.length === 1) {
-        argument = JSON.stringify(args[0]);
+        argument = JSON.stringify(args[0])
       } else {
-        argument = JSON.stringify(args);
+        argument = JSON.stringify(args)
       }
 
       if (window.androidListener) {
         if (eventName in window.androidListener) {
-          window.androidListener[eventName](argument);
+          window.androidListener[eventName](argument)
         } else {
           console.warn(`Can't pass message to native code because "${eventName}" handler is not registered`)
         }


### PR DESCRIPTION
## Why is this change being made?
> Right now, strings are serialized into the string inside a string, arriving as `""aadadda""`, we have to strip the redundant quotation marks. This change handle string as a single argument without JSON serialization for webview callback

## How was this tested? How can the reviewer verify your testing?
It can be tested with Android WebView sample app.
https://github.com/ketch-sdk/ketch-samples/pull/22

Steps to reproduce:
1. Run the app in the Android emulator
2. Go to  chrome://inspect in your browser
3. Observe the events fired in the console

String arguments arrive should arrive as regular strings without quotation marks, for ex. callbacks like `tcf_updated`.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
