### PR TITLE
fix(identity): google analytics id trim

### DIFF
--- a/src/Ketch.ts
+++ b/src/Ketch.ts
@@ -1129,8 +1129,8 @@ export class Ketch extends EventEmitter {
     const match = pattern.exec(input)
 
     if (match) {
-      // If a match is found, return the identity component
-      return match[1]
+      // If a match is found, convert to GA4 identity GA1.1.X
+      return "GA1.1."+match[1]
     }
 
     return input
@@ -1153,8 +1153,9 @@ export class Ketch extends EventEmitter {
     for (const key in newIdentities) {
       // this is a solution for customers who use the Google Analytics identifier as their primary identity space
       // with the identity space code google_analytics_cookie
-      if (key === 'google_analytics_cookie') {
-        l.debug('trimming google_analytics_cookie to get only id without GA1.X. prefix')
+      if (key === 'google_analytics_cookie' &&
+        (this._config.organization.code === 'utc' || this._config.organization.code === 'vara_labs')) {
+        l.debug('altering google_analytics_cookie to get id with GA1.1. prefix')
         newIdentities[key] = this.extractGAID(newIdentities[key])
       }
 

--- a/src/Ketch.ts
+++ b/src/Ketch.ts
@@ -1130,7 +1130,7 @@ export class Ketch extends EventEmitter {
 
     if (match) {
       // If a match is found, convert to GA4 identity GA1.1.X
-      return "GA1.1."+match[1]
+      return 'GA1.1.' + match[1]
     }
 
     return input
@@ -1153,8 +1153,10 @@ export class Ketch extends EventEmitter {
     for (const key in newIdentities) {
       // this is a solution for customers who use the Google Analytics identifier as their primary identity space
       // with the identity space code google_analytics_cookie
-      if (key === 'google_analytics_cookie' &&
-        (this._config.organization.code === 'utc' || this._config.organization.code === 'vara_labs')) {
+      if (
+        key === 'google_analytics_cookie' &&
+        (this._config.organization.code === 'utc' || this._config.organization.code === 'vara_labs')
+      ) {
         l.debug('altering google_analytics_cookie to get id with GA1.1. prefix')
         newIdentities[key] = this.extractGAID(newIdentities[key])
       }

--- a/src/Ketch.ts
+++ b/src/Ketch.ts
@@ -1125,12 +1125,12 @@ export class Ketch extends EventEmitter {
    * @param input GA cookie value
    */
   extractGAID(input: string): string {
-    const pattern = /^GA\d\.\d\.(\d+\.\d+)$/;
-    const match = pattern.exec(input);
+    const pattern = /^GA\d\.\d\.(\d+\.\d+)$/
+    const match = pattern.exec(input)
 
     if (match) {
       // If a match is found, return the identity component
-      return match[1];
+      return match[1]
     }
 
     return input


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This is a customer use case for extracting the identity from a Google Analytics cookie
The cookie is formatted as GA1.2.123.123 or GA1.1.123.123 where the first version is set by universal analytics
and the second version is set by GA4. Some customers have both tags on the page leading to inconsistent identity.

      // this is a solution for customers who use the Google Analytics identifier as their primary identity space
      // with the identity space code google_analytics_cookie

## Why is this change being made?
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
