### PR TITLE
chore: use query strings

### DIFF
--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -104,13 +104,13 @@ export default class Builder {
       return false
     }
 
+    const url = cfg.services.telemetry
+
     const percentage = parseFloat(cfg.options?.beaconPercentage || '0.1')
     let shouldSendBeacon = Math.random() < percentage
     if (!shouldSendBeacon) {
       return false
     }
-
-    const telemetryURL = new URL(cfg.services.telemetry)
 
     const request: GetConsentRequest = {
       organizationCode: cfg.organization.code ?? '',
@@ -128,10 +128,17 @@ export default class Builder {
       if (document.visibilityState === 'hidden' && shouldSendBeacon) {
         shouldSendBeacon = false
         const data = this.collectTelemetry(hasConsent, cfg, params)
-        navigator.sendBeacon(telemetryURL, data)
+        this.sendBeacon(url, data)
       }
     })
     return true
+  }
+
+  sendBeacon(url: string, data: FormData) {
+    // https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/URLSearchParams#options
+    const urlParams = new URLSearchParams(data as any).toString()
+
+    navigator.sendBeacon(`${url}?${urlParams}`)
   }
 
   collectTelemetry(hasConsent: boolean, cfg: Configuration, params: object): FormData {

--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -128,21 +128,16 @@ export default class Builder {
       if (document.visibilityState === 'hidden' && shouldSendBeacon) {
         shouldSendBeacon = false
         const data = this.collectTelemetry(hasConsent, cfg, params)
-        this.sendBeacon(url, data)
+        // https://developer.fastly.com/solutions/tutorials/beacon-termination/
+        // Use url params as recommended
+        navigator.sendBeacon(`${url}?${data.toString()}`)
       }
     })
     return true
   }
 
-  sendBeacon(url: string, data: FormData) {
-    // https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/URLSearchParams#options
-    const urlParams = new URLSearchParams(data as any).toString()
-
-    navigator.sendBeacon(`${url}?${urlParams}`)
-  }
-
-  collectTelemetry(hasConsent: boolean, cfg: Configuration, params: object): FormData {
-    const data = new FormData()
+  collectTelemetry(hasConsent: boolean, cfg: Configuration, params: object): URLSearchParams {
+    const data = new URLSearchParams()
 
     const currentURL = `${window.location.protocol}//${window.location.host}${window.location.pathname}`
 

--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -104,8 +104,6 @@ export default class Builder {
       return false
     }
 
-    const url = cfg.services.telemetry
-
     const percentage = parseFloat(cfg.options?.beaconPercentage || '0.1')
     let shouldSendBeacon = Math.random() < percentage
     if (!shouldSendBeacon) {
@@ -130,7 +128,7 @@ export default class Builder {
         const data = this.collectTelemetry(hasConsent, cfg, params)
         // https://developer.fastly.com/solutions/tutorials/beacon-termination/
         // Use url params as recommended
-        navigator.sendBeacon(`${url}?${data.toString()}`)
+        navigator.sendBeacon(`${cfg.services?.telemetry}?${data.toString()}`)
       }
     })
     return true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
> Fastly documentation recommends using query params instead of request body.  Hence this change.

<img width="1138" alt="image" src="https://github.com/ketch-sdk/ketch-tag/assets/1160815/1f555810-f1a9-48a9-9100-76447c6a10e6">


> All in all, and especially considering the bug in Chrome, we recommend constructing a [URLSearchParams]
> (https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) and simply serializing it on the end of the beacon URL as shown above.

## Why is this change being made?
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
> To be tested after updating semaphore

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
> Fix [#1]()

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [X] I have informed stakeholders of my changes.
