### PR TITLE
fix(kd-10138): remove experience switching logic

### DIFF
--- a/src/Ketch.ts
+++ b/src/Ketch.ts
@@ -355,6 +355,8 @@ export class Ketch extends EventEmitter {
   /**
    * Selects the correct experience. If the default experience is modal, but there are no purposes requiring opt in
    * then the experience is changed to banner.
+   * Per https://ketch-com.atlassian.net/browse/KD-10138 this function is now dead code (not referenced) as this
+   * check is no longer desired
    */
   selectConsentExperience(): ConsentExperienceType {
     const l = wrapLogger(log, 'selectConsentExperience')
@@ -439,7 +441,9 @@ export class Ketch extends EventEmitter {
 
     if (this.listenerCount(constants.SHOW_CONSENT_EXPERIENCE_EVENT) > 0) {
       this.willShowExperience(ExperienceType.Consent)
-      this.emit(constants.SHOW_CONSENT_EXPERIENCE_EVENT, consent, { displayHint: this.selectConsentExperience() })
+      this.emit(constants.SHOW_CONSENT_EXPERIENCE_EVENT, consent, {
+        displayHint: this._config.experiences?.consent?.experienceDefault,
+      })
     }
 
     return consent

--- a/src/Ketch.ts
+++ b/src/Ketch.ts
@@ -364,7 +364,7 @@ export class Ketch extends EventEmitter {
       this._config.experiences?.consent?.experienceDefault === ExperienceDefault.MODAL
     ) {
       for (const pa of this._config.purposes) {
-        if (!pa.requiresDisplay) {
+        if (pa.requiresDisplay) {
           l.debug(ConsentExperienceType.Modal)
           return ConsentExperienceType.Modal
         }
@@ -372,6 +372,7 @@ export class Ketch extends EventEmitter {
     }
 
     l.debug(ConsentExperienceType.Banner)
+    // return ConsentExperienceType.Banner
     return ConsentExperienceType.Banner
   }
 

--- a/src/Ketch.ts
+++ b/src/Ketch.ts
@@ -355,8 +355,6 @@ export class Ketch extends EventEmitter {
   /**
    * Selects the correct experience. If the default experience is modal, but there are no purposes requiring opt in
    * then the experience is changed to banner.
-   * Per https://ketch-com.atlassian.net/browse/KD-10138 this function is now dead code (not referenced) as this
-   * check is no longer desired
    */
   selectConsentExperience(): ConsentExperienceType {
     const l = wrapLogger(log, 'selectConsentExperience')

--- a/src/Ketch.ts
+++ b/src/Ketch.ts
@@ -366,7 +366,7 @@ export class Ketch extends EventEmitter {
       this._config.experiences?.consent?.experienceDefault === ExperienceDefault.MODAL
     ) {
       for (const pa of this._config.purposes) {
-        if (pa.requiresOptIn) {
+        if (!pa.requiresDisplay) {
           l.debug(ConsentExperienceType.Modal)
           return ConsentExperienceType.Modal
         }
@@ -441,9 +441,10 @@ export class Ketch extends EventEmitter {
 
     if (this.listenerCount(constants.SHOW_CONSENT_EXPERIENCE_EVENT) > 0) {
       this.willShowExperience(ExperienceType.Consent)
-      this.emit(constants.SHOW_CONSENT_EXPERIENCE_EVENT, consent, {
-        displayHint: this._config.experiences?.consent?.experienceDefault,
-      })
+      // this.emit(constants.SHOW_CONSENT_EXPERIENCE_EVENT, consent, {
+      //   displayHint: this._config.experiences?.consent?.experienceDefault || ExperienceDefault.MODAL,
+      // })
+      this.emit(constants.SHOW_CONSENT_EXPERIENCE_EVENT, consent, { displayHint: this.selectConsentExperience() })
     }
 
     return consent


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
> Remove logic that changes rendered experience based on `at least 1 purpose requires opt-in`

## Why is this change being made?
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
> will test in UAT

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

> https://ketch-com.atlassian.net/browse/KD-10138

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.
