### PR TITLE
fix(kd-10138): update display modal vs. banner logic based on purposes config

### DIFF
--- a/src/Ketch.test.ts
+++ b/src/Ketch.test.ts
@@ -309,6 +309,7 @@ describe('Ketch', () => {
           {
             code: 'analytics',
             requiresOptIn: true,
+            requiresDisplay: true,
           },
         ],
         experiences: {

--- a/src/Ketch.ts
+++ b/src/Ketch.ts
@@ -364,7 +364,7 @@ export class Ketch extends EventEmitter {
       this._config.experiences?.consent?.experienceDefault === ExperienceDefault.MODAL
     ) {
       for (const pa of this._config.purposes) {
-        if (pa.requiresOptIn) {
+        if (pa.requiresDisplay) {
           l.debug(ConsentExperienceType.Modal)
           return ConsentExperienceType.Modal
         }

--- a/src/Ketch_Consent.test.ts
+++ b/src/Ketch_Consent.test.ts
@@ -74,6 +74,7 @@ describe('consent', () => {
         description: 'We will use data collected about you to perform critical product enhancements.',
         legalBasisCode: 'disclosure',
         requiresPrivacyPolicy: true,
+        requiresDisplay: true,
       },
       // @ts-ignore
       {
@@ -388,7 +389,7 @@ describe('consent', () => {
   })
 
   describe('selectExperience', () => {
-    it('returns modal if any purposes requires opt in and defaultExperience is modal', () => {
+    it('returns modal if any purposes requires display in and defaultExperience is modal', () => {
       const ketch = new Ketch(new KetchWebAPI(''), {
         purposes: [
           {
@@ -397,6 +398,7 @@ describe('consent', () => {
             description: '',
             legalBasisCode: '',
             requiresOptIn: true,
+            requiresDisplay: true,
           },
         ],
         experiences: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
> change switch to banner from modal logic based on if purpose requiersDisplay instead of requiresOptIn

## Why is this change being made?
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
> tests updated

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
> https://ketch-com.atlassian.net/browse/KD-10138

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
