### PR TITLE
fix: handle no purposes error in showPreferencesExperience

### DIFF
--- a/src/Ketch.ts
+++ b/src/Ketch.ts
@@ -46,7 +46,7 @@ import parameters from './parameters'
 import Watcher from '@ketch-sdk/ketch-data-layer'
 import { CACHED_CONSENT_TTL, getCachedConsent, setCachedConsent, setPublicConsent } from './cache'
 import deepEqual from 'nano-equal'
-import constants from './constants'
+import constants, { EMPTY_CONSENT } from './constants'
 import { wrapLogger } from '@ketch-sdk/ketch-logging'
 import InternalRouter from './InternalRouter'
 
@@ -524,7 +524,21 @@ export class Ketch extends EventEmitter {
     const l = wrapLogger(log, 'showPreferenceExperience')
     l.debug(params)
 
-    const consent = await this.getConsent()
+    let consent: Consent
+    let showConsentsTab = true
+
+    try {
+      consent = await this.getConsent()
+    } catch (e: any) {
+      // "No Purposes" errors shouldn't block showing a preferences experience
+      // In this case, continue on w/ empty consent, and hide the consents tab
+      if (e === errors.noPurposesError) {
+        consent = EMPTY_CONSENT
+        showConsentsTab = false
+      } else {
+        throw e
+      }
+    }
 
     // if no preference experience configured do not show
     if (!this._config.experiences?.preference) {
@@ -551,7 +565,7 @@ export class Ketch extends EventEmitter {
 
       if (selectedTabs?.length) {
         params.showOverviewTab = selectedTabs.includes(Tab.Overview)
-        params.showConsentsTab = selectedTabs.includes(Tab.Consents)
+        params.showConsentsTab = showConsentsTab && selectedTabs.includes(Tab.Consents)
         params.showSubscriptionsTab = selectedTabs.includes(Tab.Subscriptions)
         params.showRightsTab = selectedTabs.includes(Tab.Rights)
         params.tab = selectedTabs.includes(params.tab || ('' as Tab)) ? params.tab : selectedTabs[0]

--- a/src/Ketch.ts
+++ b/src/Ketch.ts
@@ -533,6 +533,7 @@ export class Ketch extends EventEmitter {
       // "No Purposes" errors shouldn't block showing a preferences experience
       // In this case, continue on w/ empty consent, and hide the consents tab
       if (e === errors.noPurposesError) {
+        l.debug('No purposes detected, experience will not display consents tab')
         consent = EMPTY_CONSENT
         showConsentsTab = false
       } else {

--- a/src/Ketch_Preferences.test.ts
+++ b/src/Ketch_Preferences.test.ts
@@ -48,5 +48,26 @@ describe('preferences', () => {
         return expect(ketch.showPreferenceExperience()).resolves.toStrictEqual({ purposes: {}, vendors: [] })
       })
     })
+
+    it('shows experience even with no purposes', () => {
+      const ketch = new Ketch(new KetchWebAPI(''), {
+        organization: { code: 'ketch' },
+        property: { code: 'web' },
+        environment: { code: 'production' },
+        jurisdiction: { code: 'default' },
+        formTemplates: [],
+        purposes: [],
+      } as Configuration)
+
+      ketch.setIdentities({ foo: 'bar' })
+      const c = {
+        purposes: {},
+        vendors: [],
+      }
+
+      return ketch.setConsent(c).then(() => {
+        return expect(ketch.showPreferenceExperience()).resolves.toStrictEqual({ purposes: {}, vendors: [] })
+      })
+    })
   })
 })

--- a/src/Ketch_Preferences.test.ts
+++ b/src/Ketch_Preferences.test.ts
@@ -1,6 +1,7 @@
 import { Configuration } from '@ketch-sdk/ketch-types'
 import { Ketch } from './'
 import { KetchWebAPI } from '@ketch-sdk/ketch-web-api'
+import { EMPTY_CONSENT } from './constants'
 
 describe('preferences', () => {
   describe('showPreferences', () => {
@@ -60,14 +61,8 @@ describe('preferences', () => {
       } as Configuration)
 
       ketch.setIdentities({ foo: 'bar' })
-      const c = {
-        purposes: {},
-        vendors: [],
-      }
 
-      return ketch.setConsent(c).then(() => {
-        return expect(ketch.showPreferenceExperience()).resolves.toStrictEqual({ purposes: {}, vendors: [] })
-      })
+      expect(ketch.showPreferenceExperience()).resolves.toStrictEqual(EMPTY_CONSENT)
     })
   })
 })

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
+import { Consent } from '@ketch-sdk/ketch-types'
+
 export default {
   FULFILLED_EVENT: 'fulfilled',
   CONSENT_EVENT: 'consent',
@@ -31,4 +33,10 @@ export default {
   PREFERENCES: 'preferences',
   API_SERVER: 'shoreline',
   API_SERVER_BASE_URL: 'https://global.ketchcdn.com/web/v2',
+}
+
+export const EMPTY_CONSENT: Consent = {
+  purposes: {},
+  vendors: [],
+  protocols: {},
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
> https://ketch-com.atlassian.net/browse/KD-12109
> Preferences experience should not exit w/ error when no purposes are found
> Instead, hide the consents tab

## Why is this change being made?
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
>Local

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
>https://ketch-com.atlassian.net/browse/KD-12109

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
