### PR TITLE
fix(ketch-tag): use copy of in-memory identities for right invocations

### DIFF
--- a/src/Ketch.ts
+++ b/src/Ketch.ts
@@ -1524,13 +1524,15 @@ export class Ketch extends EventEmitter {
       return
     }
 
-    let identities: Identities = {}
+    const rightInvocationIdentities: Identities = {}
     if (this._identities.isFulfilled()) {
-      identities = this._identities.value
+      Object.entries(this._identities.value).forEach(([key, value]) => {
+        rightInvocationIdentities[key] = value
+      })
     }
 
     // add email identity from rights form
-    identities['email'] = eventData.subject.email
+    rightInvocationIdentities['email'] = eventData.subject.email
 
     if (
       !this._config ||
@@ -1552,7 +1554,7 @@ export class Ketch extends EventEmitter {
       propertyCode: this._config.property.code ?? '',
       environmentCode: this._config.environment.code,
       controllerCode: '',
-      identities: identities,
+      identities: rightInvocationIdentities,
       jurisdictionCode: this._config.jurisdiction.code ?? '',
       rightCode: eventData.right,
       user: user,

--- a/src/Ketch_Rights.test.ts
+++ b/src/Ketch_Rights.test.ts
@@ -92,6 +92,68 @@ describe('rights', () => {
       })
     })
 
+    const identities = {
+      space1: 'id1',
+    }
+
+    it('invoke right does not populate email in update consent', () => {
+      fetchMock.mockResponse(JSON.stringify({}))
+
+      ketch.invokeRight(data).then(() => {
+        const { property, jurisdiction, organization, environment } = config
+        expect(property).not.toBeNull()
+        expect(jurisdiction).not.toBeNull()
+        expect(organization).not.toBeNull()
+        expect(environment).not.toBeNull()
+
+        if (property && jurisdiction && organization && environment) {
+          // eslint-disable-next-line jest/no-conditional-expect
+          expect(fetchMock).toHaveBeenCalledWith('https://global.ketchcdn.com/web/v2/rights/org/invoke', {
+            body: '{"organizationCode":"org","propertyCode":"app","environmentCode":"env","controllerCode":"","identities":{"email":"rights@email.com"},"jurisdictionCode":"ps","rightCode":"portability","user":{"email":"rights@email.com","firstName":"first","lastName":"last","country":"United States","stateRegion":"California"}}',
+            credentials: 'omit',
+            headers: {
+              Accept: 'application/json',
+              'Content-Type': 'application/json',
+            },
+            method: 'POST',
+            mode: 'cors',
+          })
+        }
+      })
+
+      fetchMock.mockResponse(async (): Promise<string> => JSON.stringify({}))
+      return ketch
+        .updateConsent(identities, {
+          purposes: {
+            pacode1: true,
+            pacode2: false,
+          },
+          vendors: ['1'],
+        })
+        .then(() => {
+          const { property, jurisdiction, organization, environment } = config
+          expect(property).not.toBeNull()
+          expect(jurisdiction).not.toBeNull()
+          expect(organization).not.toBeNull()
+          expect(environment).not.toBeNull()
+
+          if (property && jurisdiction && organization && environment) {
+            expect(fetchMock).toHaveBeenCalledWith('https://global.ketchcdn.com/web/v2/consent/org/update', {
+              body: `{"organizationCode":"org","propertyCode":"app","environmentCode":"env","identities":{"space1":"id1"},"jurisdictionCode":"ps","purposes":{"pacode1":{"allowed":"true","legalBasisCode":"lb1"},"pacode2":{"allowed":"false","legalBasisCode":"lb2"}},"vendors":["1"],"collectedAt":${Math.floor(
+                Date.now() / 1000,
+              )}}`,
+              credentials: 'omit',
+              headers: {
+                Accept: 'application/json',
+                'Content-Type': 'application/json',
+              },
+              method: 'POST',
+              mode: 'cors',
+            })
+          }
+        })
+    })
+
     const dataNoEmail = {
       right: 'portability',
       subject: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Use a copy of the in-memory identities for right invocations and then add the email identity to that identity list copy. This ensures that a consent call that happens right after a right invocations request does not accidentally have an email identity in there, which was happening because the right invocation request was mutating the in-memory identity list that the consent call was using.

## Why is this change being made?
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tested, all existing tests passed and also added a new test case which passed as well
<img width="427" alt="Screenshot 2024-03-19 at 9 29 41 AM" src="https://github.com/ketch-sdk/ketch-tag/assets/40331325/9fef5e4e-8592-4b4c-881d-2f0dae5e0759">


## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://ketch-com.slack.com/archives/C02GA8GJAR5/p1709929343214609?thread_ts=1703028789.368009&cid=C02GA8GJAR5 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [X] I have informed stakeholders of my changes.
