### PR TITLE
feat: allow all trackers by overriding consent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4329,9 +4329,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
-      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "dev": true,
       "funding": [
         {
@@ -12636,9 +12636,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
-      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "dev": true
     },
     "for-each": {

--- a/src/Trackers.test.ts
+++ b/src/Trackers.test.ts
@@ -36,17 +36,17 @@ describe('Trackers', () => {
     purposes: [
       // @ts-ignore
       {
-        code: 'pacode1',
+        code: '0',
         legalBasisCode: 'lb1',
       },
       // @ts-ignore
       {
-        code: 'pacode2',
+        code: '1',
         legalBasisCode: 'lb2',
       },
       // @ts-ignore
       {
-        code: 'pacode4',
+        code: '2',
         legalBasisCode: 'lb4',
       },
     ],

--- a/src/Trackers.test.ts
+++ b/src/Trackers.test.ts
@@ -1,0 +1,83 @@
+import Trackers from './Trackers'
+import Builder from './Builder'
+import { Configuration } from '@ketch-sdk/ketch-types'
+import fetchMock from 'jest-fetch-mock'
+import errors from './errors'
+
+describe('Trackers', () => {
+  // @ts-ignore
+  const config: Configuration = {
+    organization: {
+      code: 'org',
+    },
+    property: {
+      code: 'app',
+    },
+    environment: {
+      code: 'env',
+    },
+    jurisdiction: {
+      code: 'ps',
+    },
+    rights: [
+      {
+        code: 'portability',
+        name: 'Portability',
+        description: 'Right to have all data provided to you.',
+        canonicalRightCode: 'get',
+      },
+      {
+        code: 'rtbf',
+        name: 'Data Deletion',
+        description: 'Right to be forgotten.',
+        canonicalRightCode: 'delete',
+      },
+    ],
+    purposes: [
+      // @ts-ignore
+      {
+        code: 'pacode1',
+        legalBasisCode: 'lb1',
+      },
+      // @ts-ignore
+      {
+        code: 'pacode2',
+        legalBasisCode: 'lb2',
+      },
+      // @ts-ignore
+      {
+        code: 'pacode4',
+        legalBasisCode: 'lb4',
+      },
+    ],
+    options: {
+      migration: '3',
+    },
+  }
+  const identities = {
+    space1: 'id1',
+  }
+
+  it('rejects on identities', async () => {
+    jest.spyOn(window.navigator, 'language', 'get').mockReturnValue('')
+    const builder = new Builder(config)
+    config.language = 'en'
+    fetchMock.mockResponseOnce(async (): Promise<string> => JSON.stringify(config))
+    const ketch = await builder.build()
+    const trackers = new Trackers(ketch, config)
+    expect(trackers).toBeTruthy()
+    await expect(trackers.enableAllConsent()).rejects.toBe(errors.noIdentitiesError)
+  })
+
+  it('resolves with consent', async () => {
+    jest.spyOn(window.navigator, 'language', 'get').mockReturnValue('')
+    const builder = new Builder(config)
+    config.language = 'en'
+    fetchMock.mockResponseOnce(async (): Promise<string> => JSON.stringify(config))
+    const ketch = await builder.build()
+    ketch.setIdentities(identities)
+    const trackers = new Trackers(ketch, config)
+    expect(trackers).toBeTruthy()
+    await expect(trackers.enableAllConsent()).resolves.toEqual({ purposes: { '0': true, '1': true, '2': true } })
+  })
+})

--- a/src/Trackers.ts
+++ b/src/Trackers.ts
@@ -1,0 +1,115 @@
+import { KetchWebAPI } from '@ketch-sdk/ketch-web-api'
+import { Configuration, Consent, GetConsentRequest, GetConsentResponse } from '@ketch-sdk/ketch-types'
+import log from './log'
+import errors from './errors'
+import { setCachedConsent, setPublicConsent } from './cache'
+import { wrapLogger } from '@ketch-sdk/ketch-logging'
+import { Ketch } from './Ketch'
+import getApiUrl from './getApiUrl'
+
+export default class Trackers {
+  constructor(ketch: Ketch, config: Configuration) {
+    this._ketch = ketch
+    this._config = config
+    this._api = new KetchWebAPI(getApiUrl(this._config))
+  }
+
+  normalizeConsent(input: GetConsentResponse, request: GetConsentRequest): GetConsentResponse {
+    if (!input.purposes) {
+      input.purposes = {}
+      return input
+    }
+
+    for (const purpose of Object.keys(input.purposes)) {
+      const x = input.purposes[purpose]
+      if (typeof x === 'string') {
+        input.purposes[purpose] = {
+          allowed: x,
+          legalBasisCode: request.purposes[purpose]?.legalBasisCode,
+        }
+      }
+    }
+
+    return input
+  }
+
+  async enableAllConsent(): Promise<Consent> {
+    const l = wrapLogger(log, 'trackers: enableAllConsent')
+
+    if (this._ketch.hasConsent()) {
+      l.trace('trackers: has consent')
+      return this._ketch.getConsent()
+    }
+
+    l.debug('trackers: obtaining and setting consent')
+
+    const identities = await this._ketch.getIdentities()
+    l.debug('trackers: identities', identities)
+
+    // If no identities or purposes defined, skip the call.
+    if (!identities || Object.keys(identities).length === 0) {
+      throw errors.noIdentitiesError
+    }
+
+    if (
+      !this._config ||
+      !this._config.property ||
+      !this._config.organization ||
+      !this._config.environment ||
+      !this._config.purposes ||
+      !this._config.jurisdiction ||
+      this._config.purposes.length === 0
+    ) {
+      throw errors.noPurposesError
+    }
+
+    const request: GetConsentRequest = {
+      organizationCode: this._config.organization.code ?? '',
+      propertyCode: this._config.property.code ?? '',
+      environmentCode: this._config.environment.code,
+      jurisdictionCode: this._config.jurisdiction.code ?? '',
+      identities: identities,
+      purposes: {},
+    }
+
+    // Add the purposes by ID with the legal basis
+    for (const pa of this._config.purposes) {
+      request.purposes[pa.code] = {
+        legalBasisCode: pa.legalBasisCode,
+      }
+    }
+
+    l.debug('trackers: calling getConsent', request)
+    const consent = this.normalizeConsent(await this._api.getConsent(request), request)
+    l.debug('trackers: getConsent returned', consent)
+
+    await setCachedConsent(consent)
+    await setPublicConsent(consent, this._config)
+
+    const newConsent: Consent = { purposes: {} }
+
+    // enable all consent
+    if (consent?.purposes) {
+      for (const [code] of Object.entries(consent.purposes)) {
+        newConsent.purposes[code] = true
+      }
+    }
+
+    if (consent.vendors) {
+      newConsent.vendors = consent.vendors
+    }
+
+    if (consent.protocols) {
+      newConsent.protocols = consent.protocols
+    }
+
+    l.debug('trackers: newConsent', newConsent)
+
+    await this._ketch.setConsent(newConsent)
+    return newConsent
+  }
+
+  protected readonly _ketch: Ketch
+  private readonly _api: KetchWebAPI
+  private readonly _config: Configuration
+}

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,7 +1,6 @@
 import log from './log'
 import Builder from './Builder'
 import Router from './Router'
-import { WebStorageCacher } from '@ketch-com/ketch-cache'
 import Trackers from './Trackers'
 
 /**
@@ -40,11 +39,11 @@ export default async function init(): Promise<void> {
   // Note that the tag has loaded
   window.semaphore.loaded = true
 
-  const emulatorWebCacher = new WebStorageCacher<boolean>(window.localStorage)
-  const isEmulatorFlow = await emulatorWebCacher.getItem('emulator')
+  const shouldOverrideConsent = window.localStorage.getItem('overrideConsent')
 
-  if (isEmulatorFlow) {
-    const trackers = new Trackers(ketch, cfg)
+  if (shouldOverrideConsent) {
+    const ketchFullConfig = await ketch.getConfig()
+    const trackers = new Trackers(ketch, ketchFullConfig)
     await trackers.enableAllConsent()
   } else {
     // Ensure consent has been loaded

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,6 +1,8 @@
 import log from './log'
 import Builder from './Builder'
 import Router from './Router'
+import { WebStorageCacher } from '@ketch-com/ketch-cache'
+import Trackers from './Trackers'
 
 /**
  * This is the entry point when this package is first loaded.
@@ -38,6 +40,14 @@ export default async function init(): Promise<void> {
   // Note that the tag has loaded
   window.semaphore.loaded = true
 
-  // Ensure consent has been loaded
-  await ketch.getConsent()
+  const emulatorWebCacher = new WebStorageCacher<boolean>(window.localStorage)
+  const isEmulatorFlow = await emulatorWebCacher.getItem('emulator')
+
+  if (isEmulatorFlow) {
+    const trackers = new Trackers(ketch, cfg)
+    await trackers.enableAllConsent()
+  } else {
+    // Ensure consent has been loaded
+    await ketch.getConsent()
+  }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

- Override and provide consent so respective tag managers triggers all tags thereby allowing all trackers to be scanned
- Has no impact on current user flows

## Why is this change being made?
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
locally

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://ketch-com.atlassian.net/browse/KD-12047
https://ketch-com.atlassian.net/browse/KD-12048

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.
