### PR TITLE
fix: handle case where window.localStorage is null

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -39,7 +39,7 @@ export default async function init(): Promise<void> {
   // Note that the tag has loaded
   window.semaphore.loaded = true
 
-  const shouldOverrideConsent = window?.localStorage.getItem('overrideConsent')
+  const shouldOverrideConsent = window?.localStorage?.getItem('overrideConsent')
 
   if (shouldOverrideConsent) {
     const ketchFullConfig = await ketch.getConfig()

--- a/src/init.ts
+++ b/src/init.ts
@@ -39,7 +39,7 @@ export default async function init(): Promise<void> {
   // Note that the tag has loaded
   window.semaphore.loaded = true
 
-  const shouldOverrideConsent = window.localStorage.getItem('overrideConsent')
+  const shouldOverrideConsent = window?.localStorage.getItem('overrideConsent')
 
   if (shouldOverrideConsent) {
     const ketchFullConfig = await ketch.getConfig()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
> Adds `?` for case when window.localStorage is null, which can happen in certain mobile webview implementations

## Why is this change being made?
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
> Description here

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
> https://ketch-com.slack.com/archives/C02EWFDVD71/p1712079195954359

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
