### PR TITLE
fix: add support for CLOSE_WITHOUT_SETTING_CONSENT

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@ketch-com/ketch-cookie": "^1.0.5",
         "@ketch-sdk/ketch-data-layer": "^1.3.2",
         "@ketch-sdk/ketch-logging": "^1.2.1",
-        "@ketch-sdk/ketch-types": "^1.37.0",
         "@ketch-sdk/ketch-web-api": "^1.6.6",
         "buffer": "^6.0.3",
         "events": "^3.3.0",
@@ -25,6 +24,7 @@
         "uuid": "^9.0.0"
       },
       "devDependencies": {
+        "@ketch-sdk/ketch-types": "^1.37.4",
         "@types/fetch-mock": "^7.3.5",
         "@types/jest": "^29.5.0",
         "@types/nano-equal": "^2.0.0",
@@ -1340,9 +1340,9 @@
       "integrity": "sha512-xl+y05BKybtvZjwZ76CrdGDbkV66riWNZMw+Zq+iCFbuOEvBzzgwrV2egFESO78q7/ejzrA51NBzcWvWYDSFgQ=="
     },
     "node_modules/@ketch-sdk/ketch-types": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@ketch-sdk/ketch-types/-/ketch-types-1.37.0.tgz",
-      "integrity": "sha512-9wBEmK5QYkPLwfia486arClKE6YdL0kc+Ol4TegWdSSshe3HnyHeHKg/N1oygUnr8RcvYantxcNeowEbh8OG2w=="
+      "version": "1.37.4",
+      "resolved": "https://registry.npmjs.org/@ketch-sdk/ketch-types/-/ketch-types-1.37.4.tgz",
+      "integrity": "sha512-UyW/KpA0cPYbjWZ5e6B+52PkUr0QYzW3Dlp2mS0shURA2nNBwWgHOh08ek6C9fR2hQzLJMpoJfV/S9INzCvRRA=="
     },
     "node_modules/@ketch-sdk/ketch-web-api": {
       "version": "1.6.6",
@@ -10302,9 +10302,9 @@
       "integrity": "sha512-xl+y05BKybtvZjwZ76CrdGDbkV66riWNZMw+Zq+iCFbuOEvBzzgwrV2egFESO78q7/ejzrA51NBzcWvWYDSFgQ=="
     },
     "@ketch-sdk/ketch-types": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@ketch-sdk/ketch-types/-/ketch-types-1.37.0.tgz",
-      "integrity": "sha512-9wBEmK5QYkPLwfia486arClKE6YdL0kc+Ol4TegWdSSshe3HnyHeHKg/N1oygUnr8RcvYantxcNeowEbh8OG2w=="
+      "version": "1.37.4",
+      "resolved": "https://registry.npmjs.org/@ketch-sdk/ketch-types/-/ketch-types-1.37.4.tgz",
+      "integrity": "sha512-UyW/KpA0cPYbjWZ5e6B+52PkUr0QYzW3Dlp2mS0shURA2nNBwWgHOh08ek6C9fR2hQzLJMpoJfV/S9INzCvRRA=="
     },
     "@ketch-sdk/ketch-web-api": {
       "version": "1.6.6",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "url": "https://github.com/ketch-sdk/ketch-tag/issues"
   },
   "devDependencies": {
+    "@ketch-sdk/ketch-types": "^1.37.4",
     "@types/fetch-mock": "^7.3.5",
     "@types/jest": "^29.5.0",
     "@types/nano-equal": "^2.0.0",
@@ -64,7 +65,6 @@
     "@ketch-com/ketch-cookie": "^1.0.5",
     "@ketch-sdk/ketch-data-layer": "^1.3.2",
     "@ketch-sdk/ketch-logging": "^1.2.1",
-    "@ketch-sdk/ketch-types": "^1.37.0",
     "@ketch-sdk/ketch-web-api": "^1.6.6",
     "buffer": "^6.0.3",
     "events": "^3.3.0",

--- a/src/Ketch.ts
+++ b/src/Ketch.ts
@@ -461,7 +461,11 @@ export class Ketch extends EventEmitter {
     this._isExperienceDisplayed = false
     this._hasExperienceBeenDisplayed = true
 
-    if (reason !== ExperienceClosedReason.SET_CONSENT) {
+    if (
+      // Send consent on close, unless we just did, or preference center is closing and doesn't want to set consent
+      reason !== ExperienceClosedReason.SET_CONSENT &&
+      reason !== ExperienceClosedReason.CLOSE_WITHOUT_SETTING_CONSENT
+    ) {
       const consent = await this.retrieveConsent()
 
       if (this._config.purposes) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
> instruct ketch-tag to close the experience without overriding consent that may have been updated by a submitted dsr

## Why is this change being made?
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
> Local

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
> https://ketch-com.atlassian.net/browse/KD-13064

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
