### PR TITLE
fix: setConsent in experienceClosed

### DIFF
--- a/src/InternalRouter.ts
+++ b/src/InternalRouter.ts
@@ -16,8 +16,8 @@ export default class InternalRouter extends Router implements KetchAPI {
     super(ketch)
   }
 
-  experienceClosed(reason: ExperienceClosedReason): Promise<void> {
-    return this._ketch.experienceClosed(reason).then(() => {})
+  experienceClosed(reason: ExperienceClosedReason, consent?: Consent): Promise<void> {
+    return this._ketch.experienceClosed(reason, consent).then(() => {})
   }
 
   invokeRight(eventData: InvokeRightEvent): Promise<void> {

--- a/src/Ketch.ts
+++ b/src/Ketch.ts
@@ -469,8 +469,8 @@ export class Ketch extends EventEmitter {
       if (consent && reason === ExperienceClosedReason.SET_CONSENT) {
         // Set consent to the value provided in the arguement
         await this.setConsent(consent, SetConsentReason.USER_UPDATE)
-      } else {
-        // Set consent to the stored value
+      } else if (reason !== ExperienceClosedReason.SET_CONSENT) {
+        // Set consent to the stored value, unless reason was setConsent with no consent provided
         const storedConsent = await this.retrieveConsent()
         if (this._config.purposes) {
           for (const p of this._config.purposes) {

--- a/src/Ketch.ts
+++ b/src/Ketch.ts
@@ -451,9 +451,10 @@ export class Ketch extends EventEmitter {
    * Signals that an experience has been hidden
    *
    * @param reason is a string representing the reason the experience was closed
-   * Values: setConsent, invokeRight, close
+   * Values: setConsent, invokeRight, willNotShow, close, closeWithoutSettingConsent
+   * @param consent is a optional object containing the consent state to set IF reason is setConsent
    */
-  async experienceClosed(reason: ExperienceClosedReason): Promise<Consent> {
+  async experienceClosed(reason: ExperienceClosedReason, consent?: Consent): Promise<Consent> {
     log.debug('experienceClosed', reason)
 
     // update isExperienceDisplayed flag when experience no longer displayed
@@ -462,21 +463,24 @@ export class Ketch extends EventEmitter {
     this._hasExperienceBeenDisplayed = true
 
     if (
-      // Send consent on close, unless we just did, or preference center is closing and doesn't want to set consent
-      reason !== ExperienceClosedReason.SET_CONSENT &&
+      // Send consent on close, unless the preference center is closing and doesn't want to set consent
       reason !== ExperienceClosedReason.CLOSE_WITHOUT_SETTING_CONSENT
     ) {
-      const consent = await this.retrieveConsent()
-
-      if (this._config.purposes) {
-        for (const p of this._config.purposes) {
-          if (consent.purposes[p.code] === undefined && p.requiresOptIn) {
-            consent.purposes[p.code] = false
+      if (consent && reason === ExperienceClosedReason.SET_CONSENT) {
+        // Set consent to the value provided in the arguement
+        await this.setConsent(consent, SetConsentReason.USER_EXPERIENCE_DISMISSAL)
+      } else {
+        // Set consent to the stored value
+        const storedConsent = await this.retrieveConsent()
+        if (this._config.purposes) {
+          for (const p of this._config.purposes) {
+            if (storedConsent.purposes[p.code] === undefined && p.requiresOptIn) {
+              storedConsent.purposes[p.code] = false
+            }
           }
         }
+        await this.setConsent(storedConsent, SetConsentReason.USER_EXPERIENCE_DISMISSAL)
       }
-
-      await this.setConsent(consent, SetConsentReason.USER_EXPERIENCE_DISMISSAL)
     }
 
     // Call functions registered using onHideExperience

--- a/src/Ketch.ts
+++ b/src/Ketch.ts
@@ -468,7 +468,7 @@ export class Ketch extends EventEmitter {
     ) {
       if (consent && reason === ExperienceClosedReason.SET_CONSENT) {
         // Set consent to the value provided in the arguement
-        await this.setConsent(consent, SetConsentReason.USER_EXPERIENCE_DISMISSAL)
+        await this.setConsent(consent, SetConsentReason.USER_UPDATE)
       } else {
         // Set consent to the stored value
         const storedConsent = await this.retrieveConsent()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
> Calls setConsent in experienceClosed when reason === setConsent

## Why is this change being made?
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
> All existing tests passed

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
<img width="780" alt="Screenshot 2024-06-20 at 4 51 15 PM" src="https://github.com/ketch-sdk/ketch-tag/assets/45305362/34f68644-f1f7-4ef0-9ad8-ef64a36fb466">


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
