### PR TITLE
fix(consent): wait for consent listener before triggering consent experience

### DIFF
--- a/src/Ketch.ts
+++ b/src/Ketch.ts
@@ -518,13 +518,26 @@ export class Ketch extends EventEmitter {
 
     const consent = await this.retrieveConsent()
 
+    // if listener subscribed, trigger event, else wait for listener
+    // this addresses the situation where lanyard loads late on the page
     if (this.listenerCount(constants.SHOW_CONSENT_EXPERIENCE_EVENT) > 0) {
-      log.debug('showConsentExperience - listener > 0')
-      this.willShowExperience(ExperienceType.Consent)
-      this.emit(constants.SHOW_CONSENT_EXPERIENCE_EVENT, consent, { displayHint: this.selectConsentExperience() })
+      await this.showConsentExperienceTrigger(consent)
+    } else {
+      this.on('addedListener', event => {
+        if (event === constants.SHOW_CONSENT_EXPERIENCE_EVENT) {
+          this.showConsentExperienceTrigger(consent)
+        }
+      })
     }
 
     return consent
+  }
+
+  async showConsentExperienceTrigger(consent?: Consent): Promise<void> {
+    log.debug('showConsentExperienceTrigger')
+
+    this.willShowExperience(ExperienceType.Consent)
+    this.emit(constants.SHOW_CONSENT_EXPERIENCE_EVENT, consent, { displayHint: this.selectConsentExperience() })
   }
 
   /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
> Waits for consent listener to be registered before calling `willShowExperience` and emitting the `showConsentExperience` event

## Why is this change being made?
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
> `npm run test`

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
> https://ketch-com.atlassian.net/browse/KD-12941 and https://ketch-com.atlassian.net/browse/KD-12943

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
