### PR TITLE
refactor: store tag blocking results to facilitate console logging function

### DIFF
--- a/src/Tags.ts
+++ b/src/Tags.ts
@@ -204,7 +204,12 @@ export default class Tags {
 
       // Update results
       this._results[elementName] = { enabledElements, disabledElements }
-      l.debug(`enabled ${elementName} elements`, enabledElements)
+      l.debug(
+        `enabled ${elementName} elements:`,
+        enabledElements,
+        `disabled ${elementName} elements:`,
+        disabledElements,
+      )
     })
 
     // Once enabling is complete, add utility functions to window object


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
> Reworks the `Tags.execute()` function to store the results of which tags were allowed vs. blocked, so that we can report them via the console `KetchLog.getWrappedTags()` function

## Why is this change being made?
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
> `npm run test`

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
> https://ketch-com.atlassian.net/browse/KD-13844?searchObjectId=31715&searchContainerId=10000&searchContentType=issue&searchSessionId=b3f3ff10-ffb2-4cae-a609-c8111ab81615

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
