### PR TITLE
fix: trim cookie name

### DIFF
--- a/src/CookieBlocker.test.ts
+++ b/src/CookieBlocker.test.ts
@@ -148,6 +148,13 @@ describe('CookieBlocker', () => {
       'cookie-4': {
         purposeCodes: ['purpose-2', 'purpose-3'],
       },
+      'cookie-5': {
+        regex: '^ab\\.storage\\.deviceId.*$',
+        purposeCodes: ['purpose-2', 'purpose-3'],
+      },
+      analytics_session_id: {
+        purposeCodes: ['purpose-2', 'purpose-3'],
+      },
     },
   }
 
@@ -184,7 +191,7 @@ describe('CookieBlocker', () => {
     expect(grantedPurposes.has('purpose-3')).toBe(false)
   })
 
-  it('deletes one cookie with regex only', async () => {
+  it('deletes one cookie with regex only - 1', async () => {
     // Mock consents
     jest.spyOn(ketch, 'getConsent').mockResolvedValue({
       purposes: {
@@ -200,6 +207,26 @@ describe('CookieBlocker', () => {
     const blockedCookies = await cookieBlocker.execute()
     expect(blockedCookies.length).toBe(1)
     expect(blockedCookies[0]).toBe('cookie-1_a')
+  })
+
+  it('deletes one cookie with regex only - 2', async () => {
+    // Mock consents
+    jest.spyOn(ketch, 'getConsent').mockResolvedValue({
+      purposes: {
+        'purpose-1': false,
+        'purpose-2': false,
+        'purpose-3': false,
+      },
+    })
+
+    // Mock cookies
+    jest
+      .spyOn(document, 'cookie', 'get')
+      .mockReturnValue(' ab.storage.deviceId.14cbcbd7-760e-49dc-a494-a4e8e89433ff=value;')
+
+    const blockedCookies = await cookieBlocker.execute()
+    expect(blockedCookies.length).toBe(1)
+    expect(blockedCookies[0]).toBe('ab.storage.deviceId.14cbcbd7-760e-49dc-a494-a4e8e89433ff')
   })
 
   it('deletes multiple cookies with regex only', async () => {
@@ -228,7 +255,7 @@ describe('CookieBlocker', () => {
     expect(blockedCookies[2]).toBe('cookie-2_c')
   })
 
-  it('deletes one cookie with exact match only', async () => {
+  it('deletes one cookie with exact match only - 1', async () => {
     // Mock consents
     jest.spyOn(ketch, 'getConsent').mockResolvedValue({
       purposes: {
@@ -244,6 +271,24 @@ describe('CookieBlocker', () => {
     const blockedCookies = await cookieBlocker.execute()
     expect(blockedCookies.length).toBe(1)
     expect(blockedCookies[0]).toBe('cookie-3')
+  })
+
+  it('deletes one cookie with exact match only - 2', async () => {
+    // Mock consents
+    jest.spyOn(ketch, 'getConsent').mockResolvedValue({
+      purposes: {
+        'purpose-1': false,
+        'purpose-2': false,
+        'purpose-3': false,
+      },
+    })
+
+    // Mock cookies
+    jest.spyOn(document, 'cookie', 'get').mockReturnValue(' analytics_session_id=1726747699422')
+
+    const blockedCookies = await cookieBlocker.execute()
+    expect(blockedCookies.length).toBe(1)
+    expect(blockedCookies[0]).toBe('analytics_session_id')
   })
 
   it('deletes multiple cookies with exact match only', async () => {

--- a/src/CookieBlocker.ts
+++ b/src/CookieBlocker.ts
@@ -55,7 +55,7 @@ export default class CookieBlocker {
 
       // Delete all cookies that match the pattern
       cookies.forEach(cookie => {
-        const [name, _] = cookie.split('=')
+        const [name, _] = cookie.trim().split('=')
         /**
          * Delete cookie if not already deleted AND either:
          *   - We have a regex pattern and the cookie name matches that pattern, or


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
> Trims whitespace on cookie string, currently there is a single whitespace on each one causing none of the regular expressions to match

## Why is this change being made?
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
> Added two tests in `CookieBlocker.test.ts` and ran via `npm run test`

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
