### PR TITLE
fix: don't set isExperienceDisplayed when no experiences in config

### DIFF
--- a/src/Ketch.ts
+++ b/src/Ketch.ts
@@ -472,6 +472,15 @@ export class Ketch extends EventEmitter {
     // Call functions registered using onWillShowExperience
     this.emit(constants.WILL_SHOW_EXPERIENCE_EVENT, type)
 
+    // Don't set this._isExperienceDisplayed if there is no experience to show in the config
+    const experienceLayout = (this._config as ConfigurationV2).experiences?.layout
+    if (
+      !experienceLayout ||
+      (type === ExperienceType.Consent && !experienceLayout.banner && !experienceLayout.modal) ||
+      (type === ExperienceType.Preference && !experienceLayout.preference)
+    )
+      return
+
     // update isExperienceDisplayed flag when experience displayed
     this._isExperienceDisplayed = true
   }

--- a/src/__mocks__/webApi.ts
+++ b/src/__mocks__/webApi.ts
@@ -29,4 +29,11 @@ export const emptyConfig = {
   jurisdiction: {
     code: 'jurisdiction',
   },
+  experiences: {
+    layout: {
+      banner: {},
+      modal: {},
+      preference: {},
+    },
+  } as any,
 } as Configuration


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
> Ensures that this._isExperienceDisplayed is not set when there is no experiences of the type (consent or preference) in the config

## Why is this change being made?
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
> `npm run test`, updated mock of empty config to include experiences

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
> https://ketch-com.atlassian.net/browse/KD-13215

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
