### PR TITLE
feat(cookie-blocking): re-execute when DOMContentLoaded fires

### DIFF
--- a/src/CookieBlocker.test.ts
+++ b/src/CookieBlocker.test.ts
@@ -394,6 +394,17 @@ describe('CookieBlocker', () => {
     expect(executeSpy).toHaveBeenCalledTimes(2)
   })
 
+  it('re-executes when DOMContentLoaded fires', async () => {
+    // Spy on the execute method of the Tags instance
+    const executeSpy = jest.spyOn(cookieBlocker, 'execute')
+    expect(executeSpy).toHaveBeenCalledTimes(0)
+
+    // Simulate the DOMContentLoaded event
+    const event = new Event('DOMContentLoaded')
+    window.dispatchEvent(event)
+    expect(executeSpy).toHaveBeenCalledTimes(1)
+  })
+
   it('verifies no errors when consent is undefined', async () => {
     // Mock consents
     jest.spyOn(ketch, 'getConsent').mockResolvedValue(undefined as unknown as Consent)

--- a/src/CookieBlocker.ts
+++ b/src/CookieBlocker.ts
@@ -16,6 +16,9 @@ export default class CookieBlocker {
 
     // Add a listener to retry whenever consent is updated
     this._ketch.on(constants.CONSENT_EVENT, () => this.execute())
+
+    // Retry whenever all non-async or dyanmically loaded scripts finish executing
+    window.addEventListener('DOMContentLoaded', () => this.execute())
   }
 
   // Return a promise containing the set of purposes codes for which we have consent

--- a/src/Tags.ts
+++ b/src/Tags.ts
@@ -209,7 +209,6 @@ export default class Tags {
     if (isPlatformMapped) {
       // Get purpose mappings from config - TODO:JB - Finish once config type is updated
       const id = element.getAttribute('data-ketch-id') || ''
-      console.log(id)
       return this._config.tags?.[id]?.purposeCodes || []
     } else {
       // Handle case where no purpose attribute defined in MappingConfig


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
> Re-execute when the DOMContentLoaded event fires, which is when any non-async or dynamically loaded scripts have finished executing

## Why is this change being made?
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
> Added test in CookieBlocker.test.ts

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
> 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
